### PR TITLE
Replace '/' in entity names to avoid ESPHome 2026.7 warning

### DIFF
--- a/components/nilan/all.yaml
+++ b/components/nilan/all.yaml
@@ -227,7 +227,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: nilan_modbus_controller
-    name: "Actual on/off state"
+    name: "Actual on-off state"
     id: nilan_actual_on_off_state
     accuracy_decimals: 0
     register_type: read
@@ -629,7 +629,7 @@ text_sensor:
 switch:
   - platform: modbus_controller
     modbus_controller_id: nilan_modbus_controller
-    name: "On/Off state"
+    name: "On-Off state"
     id: nilan_on_off_state
     register_type: holding
     bitmask: 1

--- a/components/nilan/all.yaml
+++ b/components/nilan/all.yaml
@@ -319,7 +319,7 @@ number:
       uint16_t firstDigit = (intVal / 60); // 1 hour is written as '100' and not '60'
       uint16_t lastDigits = (intVal % 60); // 1:30 hours is written as '130' and not '90'
       uint16_t result = (firstDigit*100) + lastDigits;
-      payload = modbus_controller::float_to_payload(result, modbus_controller::SensorValueType::U_WORD);
+      payload = modbus::helpers::float_to_payload(result, modbus::helpers::SensorValueType::U_WORD);
       return x;
     step: 1.0
     address: 602


### PR DESCRIPTION
Prepare for ESPHome 2026.7.0

WARNING 'Actual on/off state' contains '/' which is reserved as a URL path separator. Automatically replacing with 'Actual on⁄off state' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0. 
WARNING 'On/Off state' contains '/' which is reserved as a URL path separator. Automatically replacing with 'On⁄Off state' (Unicode FRACTION SLASH). Please update your configuration. This will become an error in ESPHome 2026.7.0.