### PR TITLE
chore: improve ESPHome 2026 compatibility (entity name + modbus deprecation fixes)

### DIFF
--- a/components/nilan/all.yaml
+++ b/components/nilan/all.yaml
@@ -227,7 +227,7 @@ sensor:
 
   - platform: modbus_controller
     modbus_controller_id: nilan_modbus_controller
-    name: "Actual on/off state"
+    name: "Actual on-off state"
     id: nilan_actual_on_off_state
     accuracy_decimals: 0
     register_type: read
@@ -629,7 +629,7 @@ text_sensor:
 switch:
   - platform: modbus_controller
     modbus_controller_id: nilan_modbus_controller
-    name: "On/Off state"
+    name: "On-Off state"
     id: nilan_on_off_state
     register_type: holding
     bitmask: 1

--- a/components/nilan/all.yaml
+++ b/components/nilan/all.yaml
@@ -319,7 +319,7 @@ number:
       uint16_t firstDigit = (intVal / 60); // 1 hour is written as '100' and not '60'
       uint16_t lastDigits = (intVal % 60); // 1:30 hours is written as '130' and not '90'
       uint16_t result = (firstDigit*100) + lastDigits;
-      payload = modbus_controller::float_to_payload(result, modbus_controller::SensorValueType::U_WORD);
+      payload = modbus::helpers::float_to_payload(result, modbus::helpers::SensorValueType::U_WORD);
       return x;
     step: 1.0
     address: 602


### PR DESCRIPTION
This PR prepares the Nilan ESPHome component for upcoming ESPHome breaking changes.

Changes included:
1. Entity name compatibility fix

Replaces / in entity names with On-Off to avoid future ESPHome validation errors (will become an error in 2026.7).

"Actual on/off state" → "Actual On-Off State"
"On/Off state" → "On-Off State"

2. Modbus API migration

Updates deprecated Modbus controller function:

modbus_controller::float_to_payload()
→ modbus::helpers::float_to_payload()

This aligns with the new ESPHome Modbus API and removes deprecation warnings ahead of removal in 2026.10.